### PR TITLE
fix: score count

### DIFF
--- a/run_domino.js
+++ b/run_domino.js
@@ -202,7 +202,7 @@ async function main() {
   const resultados = [0, 0];
   for (let i = 0; i < options.games; ++i) {
     const ganhador = await runGame();
-    resultados[ganhador - 1] += 1;
+    resultados[jogadores[ganhador].bot - 1] += 1;
     console.log(`Partida ${i + 1}: Vencedor: bot${jogadores[ganhador].bot}.`);
     console.log(`  Resultado parcial: bot1 ${resultados[0]} x ${resultados[1]} bot2`);
     console.log();


### PR DESCRIPTION
`resultados` é um array referente ao bot1 e bot 2 respectivamente `[3, 7]` deve significar que o bot 1 fez 3 pontos e o bot 2 fez 7.

`ganhador` é referente a dupla ganhadora:  `1` para as dupla de jogadores 1 e 3 ou `2` para a dupla de jogadores 2 e 4.

Em uma situação onde o bot 1 é iniciado como duplas 2 e 4, a pontuação é na realidade tratada da forma invertida

![image](https://github.com/cubos/desafio-domino/assets/54548671/f750a63c-865c-4994-aee3-26480471da0c)
![image](https://github.com/cubos/desafio-domino/assets/54548671/97f2cbd3-ffaa-470d-b9a7-fdff2804bf7a)

Após essa correção os `resultados` adicionam o ganhador baseado no bot vencedor de fato:

![image](https://github.com/cubos/desafio-domino/assets/54548671/c6978426-6e4f-4941-8b71-1aeab903888f)
![image](https://github.com/cubos/desafio-domino/assets/54548671/d981b63b-e709-406c-97a9-0339e8257f19)
